### PR TITLE
Rename Perseverance Up to Fortitude Up

### DIFF
--- a/resources/javascript/data.js
+++ b/resources/javascript/data.js
@@ -1231,7 +1231,7 @@ CodeVeinBuilder.data.passive = {
     }
   },
   
-  C5 : { // Perseverance Up
+  C5 : { // Fortitude Up
     image : 'perseverance-up',
     tree : _lang.tree.light,
     origin : 'A16',
@@ -1687,7 +1687,7 @@ CodeVeinBuilder.data.order.passive = [
   'C2', // Mind Up
   'C3', // Willpower Up
   'C4', // Vitality Up
-  'C5', // Perseverance Up
+  'C5', // Fortitude Up
   'C6', // Strength/Dexterity Up
   'C7', // Strength/Willpower Up
   'C8', // Strength/Vitality Up

--- a/resources/lang/en/lang.js
+++ b/resources/lang/en/lang.js
@@ -670,7 +670,7 @@ window._lang = {
       },
       
       C5 : {
-        name : 'Perseverance Up',
+        name : 'Fortitude Up',
         desc : 'Increases fortitude.'
       },
       


### PR DESCRIPTION
Perseverance Up was the name used in the demo (which also had some different names for blood codes, like Aset for Isis and Thoth for Hermes) but in the final release (as far as I know) it's always been Fortitude Up.

I did this using the web interface (which doesn't support editing multiple files in one commit) because I was lazy; do you want it squashed, or can you do that yourself?